### PR TITLE
Change Cloudflare from hard to easy

### DIFF
--- a/services.json
+++ b/services.json
@@ -918,9 +918,9 @@
          },
          {
             "name":"Cloudflare",
-            "deleteurl":"https:\/\/support.cloudflare.com\/requests\/new",
-            "difficulty":"hard",
-            "description":"Submit a support ticket using the \"Account\" category, and request account deletion in the message body. You must have no domains or credit cards attached to your account prior to requesting deletion.",
+            "deleteurl":"https://dash.cloudflare.com/profile",
+            "difficulty":"easy",
+            "description":"Log in to the Cloudflare dashboard -> Go to 'My Profile' -> scroll down to 'Delete this user'-Link",
             "domain":"cloudflare.com,",
             "deletemail":null
          },

--- a/services.json
+++ b/services.json
@@ -918,7 +918,7 @@
          },
          {
             "name":"Cloudflare",
-            "deleteurl":"https://dash.cloudflare.com/profile",
+            "deleteurl":"https:\/\/dash.cloudflare.com\/profile",
             "difficulty":"easy",
             "description":"Log in to the Cloudflare dashboard -> Go to 'My Profile' -> scroll down to 'Delete this user'-Link",
             "domain":"cloudflare.com,",


### PR DESCRIPTION
Just deleted my account by following this HowTo: https://developers.cloudflare.com/fundamentals/account-and-billing/account-billing/delete-account/#delete-your-cloudflare-account-1

I don't know how many steps count as extra steps and whether this is considered medium or easy.

You have to go to your profile, click a link and then enter your login information and confirm by typing 'DELETE' in a text field. Seemed easy to me, but I can change that if you disagree.