### PR TITLE
Update itch.io

### DIFF
--- a/services.json
+++ b/services.json
@@ -2774,9 +2774,9 @@
          },
          {
             "name":"itch.io",
-            "deleteurl":"https:\/\/itch.io\/support",
-            "difficulty":"hard",
-            "description":"You need to contact support via email to get your account deleted.",
+            "deleteurl":"https:\/\/itch.io\/user\/settings\/delete-account",
+            "difficulty":"easy",
+            "description":"Log into the account and go to Account Settings, then Delete Account. Follow the instructions.",
             "domain":"itch.io,",
             "deletemail":null
          },


### PR DESCRIPTION
Add link to the delete account tool directly on the site instead of prompting users to contact support.

Disclaimer: I am associated with itch.io. We want to discourage people from sending in support messages and instead use the self-service tool.